### PR TITLE
Add community engagement document.

### DIFF
--- a/community.rst
+++ b/community.rst
@@ -1,0 +1,48 @@
+Community Engagement
+====================
+
+CWRU has plenty of cool stuff going on, and HacSoc presents some awesome weekly
+events (not to mention LinkState and HackCWRU).  So it's not like HacSoc members
+should feel like they're lacking in community engagement.  But the fact is that
+Cleveland has a surprisingly active tech scene, and every HacSoc member should
+really consider participating in it as much as possible!  It'll end up
+benefitting everyone:
+
+- You'll learn plenty from really cool talks that are put on by Cleveland
+  interest groups.  There are quite a few interest groups out there, so if you
+  spend a little time looking, you probably can find one for your interests.
+- You'll meet really cool people, many of whom do things like hiring at tech
+  companies, who may just be interested in hiring a smart, self-motivated HacSoc
+  member that comes to their tech meetups!
+- The more HacSoc members head out to these tech meetups, the more our
+  reputation and name spreads around the community.  That means, among other things:
+
+  - More people and companies coming to us, interested in giving HacSoc talks.
+  - HacSoc members become more valued in the eyes of companies who hear about us!
+
+Here are some pointers for places to start getting involved with the Cleveland
+Tech scene:
+
+**Cleveland Tech Slack**
+
+Join the Cleveland Tech Slack team!  You can sign up `here
+<https://cleveland-tech.herokuapp.com/>`_, and once you have an account you can
+join the conversation `here <https://cleveland-tech.slack.com>`_.  Be sure to
+introduce yourself on the #intro channel, and join as many topic-specific
+channels as you are interested in.  Watch out for announcements of meetups here.
+But, this probably isn't the place to have notifications on for any activity, so
+you'll have to peruse the messages every now and then.
+
+**Cleveland Python Area Interest Group**
+
+There is a `Cleveland Python Interest Group
+<http://www.meetup.com/Cleveland-Area-Python-Interest-Group/>`_.  They have
+meetups every so often at the LeanDog boat, complete with talks, beer, pizza,
+and friendly tech conversation.  If you are at all interested in Python, it may
+be worth signing up and getting the emails, so you can remember to make your way
+out there for their meetups.
+
+**Cleveland Big Data and Hadoop User Group (CHUG)**
+
+Similarly, there is the Cleveland Big Data and Hadoop User Group (CHUG for
+short).  They are also on `Meetup <http://www.meetup.com/Cleveland-Hadoop/>`_.

--- a/community.rst
+++ b/community.rst
@@ -46,3 +46,30 @@ out there for their meetups.
 
 Similarly, there is the Cleveland Big Data and Hadoop User Group (CHUG for
 short).  They are also on `Meetup <http://www.meetup.com/Cleveland-Hadoop/>`_.
+
+**Other Meetups**
+
+You can find a ton of potentially interesting Meetup groups on `Meetup
+<http://www.meetup.com>`_, if you browse through Cleveland.  Here is a small
+dump of potentially interesting ones:
+
+- `Cleveland Game Developers <http://www.meetup.com/clevelandgamedev/>`_
+- `Rosetta Tech Talks <http://www.meetup.com/RosettaTechTalks/>`_
+- `Cleveland Ruby Brigade <http://www.meetup.com/ClevelandRuby/>`_
+- `Cleveland NodeSchool <http://www.meetup.com/NodeSchool-Cleveland/>`_
+- `Cleveland Web Design and Development <http://www.meetup.com/Cleveland-Web-Design-and-Development-Meetup/>`_
+- `xDD-CLE (x-Driven Development) <http://www.meetup.com/xDD-CLE/>`_
+- `Cleveland Node.js User Group <http://www.meetup.com/NodejsCleveland/>`_
+- `Cleveland JavaScript Meetup <http://www.meetup.com/Cleveland-JavaScript-Meetup/>`_
+- `We Can Code It <http://www.meetup.com/WeCanCodeIt/>`_
+- `Cleveland Dev Craft (Microsoft Stack) <http://www.meetup.com/cledevcraft/>`_
+- `GiveSec <http://www.meetup.com/GiveSec/>`_
+
+**Cleveland Tech Events**
+
+This probably should be higher up, but Cleveland Tech Events seems to be a
+really awesome website that aggregates a lot of announcements for tech related
+events, as well as links to even more resources for the CLE community.  Check it
+out:
+
+http://clevelandtechevents.com/

--- a/index.rst
+++ b/index.rst
@@ -14,6 +14,7 @@ Contents:
    organizational/index
    technical/index
    directory
+   community
 
 
 Indices and tables


### PR DESCRIPTION
I posted some of this info on Slack, but then realized that it's probably better off in a more accessible, well-documented area like this Wiki.  I don't know a ton about the community engagement opportunities, but I'm hoping that other people can fill in the gaps for me (maybe @StephHippo knows some additional groups I didn't mention here).

(Also, Sphinx builds without error on this, so it's safe to merge.)
