### PR TITLE
Change @imbstack's URL.

### DIFF
--- a/directory.rst
+++ b/directory.rst
@@ -26,4 +26,4 @@ Alumni
 ------
 
 - Steph Hippo: http://stephhippo.com
-- Brian Stack: http://bis12.github.io
+- Brian Stack: http://imbstack.github.io


### PR DESCRIPTION
HacSoc never forgets.  HacSoc detects changed URLs and updates them.  Manually, I guess.
